### PR TITLE
Rule updates

### DIFF
--- a/detection_rules/okta/google_workspace_downloads_folder_internal_user.yaral
+++ b/detection_rules/okta/google_workspace_downloads_folder_internal_user.yaral
@@ -1,0 +1,23 @@
+rule google_workspace_downloads_folder_internal_user {
+  meta:
+    author = "Algbra (Mikail Tunç) | SEP2 (Adam Smith)"
+    description = "Matches when someone right click --> downloads one or more folders from Drive. Works by matching exact timestamps across >1 file."
+    severity = "Medium"
+
+  events:
+    $filedownload_event.metadata.product_event_type = "download" nocase
+    $filedownload_event.metadata.vendor_name = "Google Workspace" nocase
+    $filedownload_event.metadata.product_name = "drive" nocase
+    $filedownload_event.metadata.event_type = "USER_RESOURCE_ACCESS"
+    $filedownload_event.target.resource.name = $filename
+    $filedownload_event.metadata.event_timestamp.nanos = $timestamp
+    $filedownload_event.principal.user.email_addresses = $username
+    //add your corporate domain here
+    re.regex($username, `.*example\.com$`) nocase
+
+  match:
+    $username,$timestamp over 1m after $filedownload_event 
+
+  condition:
+    #filedownload_event > 1
+}

--- a/detection_rules/okta/okta_account_sharing.yaral
+++ b/detection_rules/okta/okta_account_sharing.yaral
@@ -10,7 +10,6 @@ rule okta_account_sharing {
     $udm.metadata.product_event_type = "user.session.start" nocase
     $udm.security_result.action = "ALLOW"
     $user = $udm.principal.user.userid        
-
     // add exclusion(s) for any IPs you expect multiple identities to be signing in from. e.g., Office IP, VPN gateway, etc.
     // $udm.principal.ip != ""
     $ip = $udm.principal.ip

--- a/detection_rules/okta/okta_failed_logins_single_account.yaral
+++ b/detection_rules/okta/okta_failed_logins_single_account.yaral
@@ -7,7 +7,7 @@ rule okta_failed_logins_single_account {
   events:
     $udm.metadata.vendor_name = "Okta" nocase
     $udm.metadata.product_name = "Okta" nocase
-    $udm.metadata.product_event_type = "user.authentication.auth_via_mfa" nocase
+    $udm.metadata.product_event_type = "user.session.start" nocase
     $udm.security_result.category_details = "INVALID_CREDENTIALS" nocase
     $user = $udm.principal.user.userid
 

--- a/detection_rules/okta/okta_user_added_to_group.yaral
+++ b/detection_rules/okta/okta_user_added_to_group.yaral
@@ -1,0 +1,26 @@
+rule okta_user_added_to_group {
+  meta:
+    author = "Algbra (Mikail Tunç) | SEP2 (Jon Cumiskey)"
+    description = "Matches when an Okta user is added to a group but not if it happened immediately after creation of the user or group"
+    severity = "Low"
+
+  events:
+    $e1.metadata.product_event_type = "user.lifecycle.create" nocase
+    $user = $e1.target.user.userid
+    $group = $e1.target.group.group_display_name 
+    $princuser = $e1.principal.user.userid
+
+    $e2.metadata.product_event_type = "group.user_membership.add" nocase
+    $user = $e2.target.user.userid
+    $princuser = $e1.principal.user.userid
+
+    $e3.metadata.product_event_type = "group.lifecycle.create" nocase
+    $group = $e3.target.group.group_display_name
+    $princuser = $e1.principal.user.userid
+
+  match:
+    $user over 1m before $e2
+
+  condition:
+    $e2 and !$e1 and !$e3
+}

--- a/detection_rules/okta/okta_user_login_multiple_geolocations.yaral
+++ b/detection_rules/okta/okta_user_login_multiple_geolocations.yaral
@@ -11,12 +11,15 @@ rule okta_user_login_multiple_geolocations {
           $udm.metadata.event_type = "USER_LOGIN" and not
           $udm.metadata.product_event_type = "security.request.blocked"
       )
-
-    // some okta authentication events have an IP from Okta datacenters so we exclude them here
-    not (
-        $udm.metadata.product_event_type = "user.authentication.sso" and
-        any $udm.security_result.detection_fields.value = "amazonaws.com"
-        )
+      // some okta authentication events have an IP from Okta datacenters so we exclude them here
+      not (
+          $udm.metadata.product_event_type = "user.authentication.sso" and
+          any $udm.security_result.detection_fields.value = "amazonaws.com"
+          )
+      not (
+          $udm.metadata.product_event_type = "user.authentication.sso" and
+          any $udm.security_result.detection_fields.value = "amazon.com inc"
+          )
 
     $country = $udm.principal.location.country_or_region
     $user = $udm.principal.user.userid


### PR DESCRIPTION
- New Google Workspace rule to detect when someone downloads an entire folder
- New Okta rule to detect when someone is added to a group unless the user or group was _just_ created

- Updated the event type we were matching on for `okta_failed_logins_single_account`. The `user.session.start` event type is a little richer and provides additional data such as the application the user attempted to login to
- Updated `okta_user_login_multiple_geolocations` to exclude another amazon ASN